### PR TITLE
Added parachute model

### DIFF
--- a/Models/parachute_model.m
+++ b/Models/parachute_model.m
@@ -1,0 +1,24 @@
+function rocket = parachute_model(rocket)
+
+if rocket.velocity(3)<-2 &&  rocket.position(3)>500
+
+drag_magnitude                  =           0.5*rocket.enviroment.air_density*rocket.chute.drogue.area*norm(rocket.velocity)^2*rocket.chute.drogue.coefficient; %calulate drag using Cd and reference area assigned in my_rocket
+drag_direction                  =           -normalize(rocket.velocity); %direction of the force is assumed to be equal to that of the rocket's velocity
+drag                            =           drag_magnitude*drag_direction;
+pos                             =           [0 0 4]'; %placeholder value
+rocket.forces.chute_drag        =           force(rocket.attitude*drag, pos);
+
+elseif rocket.velocity(3)<-2 &&  rocket.position(3)<500
+
+drag_magnitude                  =           0.5*rocket.enviroment.air_density*rocket.chute.main.area*norm(rocket.velocity)^2*rocket.chute.main.coefficient;
+drag_direction                  =           -normalize(rocket.velocity);
+drag                            =           drag_magnitude*drag_direction;
+pos                             =           [0 0 4]';
+rocket.forces.chute_drag        =          force(rocket.attitude*drag, pos);
+
+else
+
+pos                              =           [0 0 4]';
+rocket.forces.chute_drag         =           force(rocket.attitude*eye(3,1), pos);
+
+end

--- a/Rockets/mjollnir.m
+++ b/Rockets/mjollnir.m
@@ -7,6 +7,7 @@ rocket.models           = {@equations_of_motion, ...
                            @propulsion_model,    ...
                            @aerodynamics_model,  ...
                            @gravity_model,       ...
+                           @parachute_model,     ...
                            @equations_of_motion};
 
 
@@ -86,3 +87,14 @@ rocket.engine.attitude                      = eye(3);
 rocket.engine.nozzle                        = struct();
 rocket.engine.nozzle.position               = [0;0;0];
 rocket.engine.nozzle.attitude               = eye(3);
+
+
+%% Parachutes:
+
+rocket.chute                                = struct();
+rocket.chute.drogue                         = struct();
+rocket.chute.drogue.coefficient             = 0.75; % Placeholder value
+rocket.chute.drogue.area                    = 0.785; % Placeholder value
+rocket.chute.main                           = struct();
+rocket.chute.main.coefficient               = 0.785; % Placeholder value
+rocket.chute.main.area                      = 7; % Placeholder value


### PR DESCRIPTION
Added the chute property in Mjollnir. The parachute model assumes the drag force from the chutes acts in the direction opposite to the rocket's velocity vector. The force is applied to a point near the nosecone. The drogue chute is set to deploy when the rocket starts descending from apogee. When a set altitude is achieved, the main chute is deployed (replacing the drogue).